### PR TITLE
Added support for writing to out.html file dynamically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 real/*
 *.png
+out.html
+*.me

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module go-get-a-job
+
+go 1.24.0
+
+require (
+	github.com/alewtschuk/dsutils v0.0.2 // indirect
+	github.com/alewtschuk/pfmt v0.0.0-20250222224735-8483e19c9953 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/alewtschuk/dsutils v0.0.2 h1:iuZtSxf+fewh3HZGlUt3SqAZxm3ItAF5DwFji4lQCOA=
+github.com/alewtschuk/dsutils v0.0.2/go.mod h1:g3r/W3Oo29fV5j9MtAzN8NWg0dzszfd8Tg1vUgoVkcA=
+github.com/alewtschuk/pfmt v0.0.0-20250222224735-8483e19c9953 h1:3n3XCMYrMA3ObO77ihZo3UsJSQyRMJcO2srX4NnrTGc=
+github.com/alewtschuk/pfmt v0.0.0-20250222224735-8483e19c9953/go.mod h1:0ORfACNyc7eNAX2eRKOMZuW6kKlJnEsU/7K9DxTLUog=

--- a/main.go
+++ b/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"os"
 	"text/template"
+
+	"github.com/alewtschuk/pfmt"
 )
 
 type Project struct {
@@ -61,9 +64,20 @@ func parseReferences() (references []Reference) {
 	return
 }
 
+func fOut(fbuf bytes.Buffer) {
+	file, err := os.Create("out.html")
+	CheckErr(err)
+	defer file.Close()
+
+	_, err = fbuf.WriteTo(file)
+	CheckErr(err)
+	pfmt.Printcln("Resume written to out.html!", 2)
+}
+
 func main() {
+	var buf bytes.Buffer
 	t, _ := template.ParseFiles("template.tmpl")
-	t.Execute(os.Stdout, struct {
+	t.Execute(&buf, struct {
 		Projects   []Project
 		Jobs       []Job
 		References []Reference
@@ -72,4 +86,5 @@ func main() {
 		Jobs:       parseJobs(),
 		References: parseReferences(),
 	})
+	fOut(buf)
 }


### PR DESCRIPTION
Program now writes out.html dynamically to out.html file when ran, rather than printing to stdout. Done by writing the template execution to a byte buffer and writing that buffer to the output file.